### PR TITLE
Fixed theme name

### DIFF
--- a/colors/material-theme.vim
+++ b/colors/material-theme.vim
@@ -59,7 +59,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "base16-materialtheme"
+let g:colors_name = "material-theme"
 
 " Highlighting function
 fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr)


### PR DESCRIPTION
Caused syntax errors on startup due to a misset theme name. Was there a reason this was set like this to begin with? This fixes the startup errors for me but I'm using neovim so I'm not sure if this causes errors on vim as well.
