### PR TITLE
Hide EndOfBuffer '~' in NeoVim

### DIFF
--- a/colors/material-theme.vim
+++ b/colors/material-theme.vim
@@ -176,6 +176,12 @@ call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none")
 call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none")
 call <sid>hi("TabLineSel",    s:gui03, s:gui01, s:cterm03, s:cterm01, "none")
 
+" Hide '~' at end of buffer in neovim
+" Set g:material_hide_endofbuffer = 0 to disable
+if has('nvim') && (!exists('g:material_hide_endofbuffer') || g:material_hide_endofbuffer == 1)
+  call <sid>hi("EndOfBuffer" s:gui00, s:gui00, s:cterm00, s:cterm00, "none")
+endif
+
 " Standard syntax highlighting
 call <sid>hi("Boolean",      s:gui0D, "", s:cterm0D, "", "none")
 call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "none")

--- a/colors/material-theme.vim
+++ b/colors/material-theme.vim
@@ -179,7 +179,7 @@ call <sid>hi("TabLineSel",    s:gui03, s:gui01, s:cterm03, s:cterm01, "none")
 " Hide '~' at end of buffer in neovim
 " Set g:material_hide_endofbuffer = 0 to disable
 if has('nvim') && (!exists('g:material_hide_endofbuffer') || g:material_hide_endofbuffer == 1)
-  call <sid>hi("EndOfBuffer" s:gui00, s:gui00, s:cterm00, s:cterm00, "none")
+  call <sid>hi("EndOfBuffer",s:gui00, s:gui00, s:cterm00, s:cterm00, "none")
 endif
 
 " Standard syntax highlighting


### PR DESCRIPTION
I do a check if the user is using NeoVim and hide them if so. The user can disable this behavior by setting g:material_hide_endofbuffer to 0 before calling colorscheme if they so desire.
